### PR TITLE
Deduplicate Credly admin handlers

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,9 +1,15 @@
-'use client'
+"use client";
 
-import { useEffect, useState } from 'react'
-import { AnimatePresence, motion } from 'framer-motion'
-import { FiAward, FiLayers, FiPlusCircle, FiRefreshCcw, FiTrash2 } from 'react-icons/fi'
-import Link from 'next/link'
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import {
+  FiAward,
+  FiLayers,
+  FiPlusCircle,
+  FiRefreshCcw,
+  FiTrash2,
+} from "react-icons/fi";
+import Link from "next/link";
 import {
   Achievement,
   AchievementKind,
@@ -11,57 +17,115 @@ import {
   badgeData,
   certificateData,
   defaultCategories,
-} from '../../lib/achievements'
+} from "../../lib/achievements";
+import {
+  credlyBadges,
+  credlyUpdateEvent,
+  mergeCredlyLists,
+  readCredlyStorage,
+  writeCredlyStorage,
+  type CredlyCategory,
+  type CredlyEmbed,
+} from "../../lib/credly";
 
-interface AchievementForm extends Omit<Achievement, 'kind'> {
-  kind: AchievementKind
+interface AchievementForm extends Omit<Achievement, "kind"> {
+  kind: AchievementKind;
 }
 
 const initialFormState: AchievementForm = {
-  kind: 'certificate',
-  title: '',
-  issuer: '',
-  date: '',
-  status: 'earned',
-  category: defaultCategories[0] ?? 'General',
-  takeaway: '',
-  imageUrl: '',
-  previewUrl: '',
-  credentialUrl: '',
-  pdfUrl: '',
-  verificationNote: '',
-}
+  kind: "certificate",
+  title: "",
+  issuer: "",
+  date: "",
+  status: "earned",
+  category: defaultCategories[0] ?? "General",
+  takeaway: "",
+  imageUrl: "",
+  previewUrl: "",
+  credentialUrl: "",
+  pdfUrl: "",
+  verificationNote: "",
+};
 
-const statusOptions: { label: string; value: AchievementStatus; helper: string }[] = [
+const statusOptions: {
+  label: string;
+  value: AchievementStatus;
+  helper: string;
+}[] = [
   {
-    label: 'Earned',
-    value: 'earned',
-    helper: 'Use for certifications and badges that are fully complete and verifiable.',
+    label: "Earned",
+    value: "earned",
+    helper:
+      "Use for certifications and badges that are fully complete and verifiable.",
   },
   {
-    label: 'Upcoming',
-    value: 'upcoming',
-    helper: 'Reserve space for milestones that are in progress or planned.',
+    label: "Upcoming",
+    value: "upcoming",
+    helper: "Reserve space for milestones that are in progress or planned.",
   },
-]
+];
 
 const tabCopy: Record<AchievementKind, { title: string; helper: string }> = {
   certificate: {
-    title: 'Certifications',
-    helper: 'Track accredited certifications, bootcamps, or intensive courses.',
+    title: "Certifications",
+    helper: "Track accredited certifications, bootcamps, or intensive courses.",
   },
   badge: {
-    title: 'Badges',
-    helper: 'Capture micro-credentials and lightweight recognitions.',
+    title: "Badges",
+    helper: "Capture micro-credentials and lightweight recognitions.",
   },
+};
+
+const credlyCategoryOptions: { label: string; value: CredlyCategory }[] = [
+  {
+    label: "Professional Certifications",
+    value: "certification",
+  },
+  {
+    label: "Digital Badges & Challenges",
+    value: "badge",
+  },
+];
+
+const credlyCategoryDescriptions: Record<CredlyCategory, string> = {
+  certification:
+    "Full-length credentials and assessments that validate in-depth skill mastery.",
+  badge:
+    "Micro-credentials, community challenges, and short-form achievements that show continued learning.",
+};
+
+const credlyScriptSrc = "https://cdn.credly.com/assets/utilities/embed.js";
+
+interface CredlyFormState {
+  rawInput: string;
+  badgeId: string;
+  category: CredlyCategory;
+  title: string;
+  issuer: string;
 }
+
+const initialCredlyForm: CredlyFormState = {
+  rawInput: "",
+  badgeId: "",
+  category: "certification",
+  title: "",
+  issuer: "",
+};
+
+const extractCredlyBadgeId = (value: string) => {
+  const pattern =
+    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+  const match = value.match(pattern);
+
+  return match?.[0] ?? "";
+};
 
 const FieldLabel = ({ label, helper }: { label: string; helper?: string }) => (
   <div className="flex flex-col gap-1">
     <span className="text-sm font-medium text-white">{label}</span>
     {helper ? <span className="text-xs text-gray-400">{helper}</span> : null}
   </div>
-)
+);
 
 const Input = ({
   className,
@@ -69,9 +133,9 @@ const Input = ({
 }: React.InputHTMLAttributes<HTMLInputElement>) => (
   <input
     {...props}
-    className={`w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-gray-500 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40 ${className ?? ''}`.trim()}
+    className={`w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-gray-500 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40 ${className ?? ""}`.trim()}
   />
-)
+);
 
 const TextArea = ({
   className,
@@ -79,42 +143,42 @@ const TextArea = ({
 }: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => (
   <textarea
     {...props}
-    className={`w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-gray-500 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40 ${className ?? ''}`.trim()}
+    className={`w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-gray-500 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40 ${className ?? ""}`.trim()}
   />
-)
+);
 
 const TabButton = ({
   isActive,
   children,
   onClick,
 }: {
-  isActive: boolean
-  children: React.ReactNode
-  onClick: () => void
+  isActive: boolean;
+  children: React.ReactNode;
+  onClick: () => void;
 }) => (
   <motion.button
     type="button"
     onClick={onClick}
     className={`flex items-center gap-2 rounded-full border px-4 py-2 text-sm uppercase tracking-wide transition-colors ${
       isActive
-        ? 'border-primary bg-primary/10 text-primary shadow-[0_0_0_1px_rgba(59,130,246,0.35)]'
-        : 'border-white/10 bg-dark text-gray-300 hover:border-primary/50 hover:text-primary'
+        ? "border-primary bg-primary/10 text-primary shadow-[0_0_0_1px_rgba(59,130,246,0.35)]"
+        : "border-white/10 bg-dark text-gray-300 hover:border-primary/50 hover:text-primary"
     }`}
     whileHover={{ scale: 1.02 }}
     whileTap={{ scale: 0.98 }}
   >
     {children}
   </motion.button>
-)
+);
 
 const PreviewCard = ({
   achievement,
   onDelete,
 }: {
-  achievement: Achievement
-  onDelete: (achievement: Achievement) => void
+  achievement: Achievement;
+  onDelete: (achievement: Achievement) => void;
 }) => {
-  const isUpcoming = achievement.status === 'upcoming'
+  const isUpcoming = achievement.status === "upcoming";
 
   return (
     <motion.article
@@ -123,25 +187,33 @@ const PreviewCard = ({
     >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex-1">
-          <p className="text-xs uppercase tracking-wide text-primary">{achievement.category}</p>
-          <h3 className="mt-1 text-lg font-semibold text-white">{achievement.title}</h3>
+          <p className="text-xs uppercase tracking-wide text-primary">
+            {achievement.category}
+          </p>
+          <h3 className="mt-1 text-lg font-semibold text-white">
+            {achievement.title}
+          </h3>
           <p className="text-xs text-gray-400">{achievement.issuer}</p>
         </div>
         <div className="flex flex-col items-end gap-2 self-end sm:flex-row sm:items-center sm:justify-end sm:gap-3">
           <span
             className={`inline-flex items-center rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-wide leading-none ${
               isUpcoming
-                ? 'border border-primary/40 text-primary/80'
-                : 'border border-emerald-400/40 text-emerald-300'
+                ? "border border-primary/40 text-primary/80"
+                : "border border-emerald-400/40 text-emerald-300"
             }`}
           >
-            {isUpcoming ? 'Upcoming' : 'Earned'}
+            {isUpcoming ? "Upcoming" : "Earned"}
           </span>
           <button
             type="button"
             onClick={() => {
-              if (window.confirm(`Remove ${achievement.title}? This only updates the preview list.`)) {
-                onDelete(achievement)
+              if (
+                window.confirm(
+                  `Remove ${achievement.title}? This only updates the preview list.`,
+                )
+              ) {
+                onDelete(achievement);
               }
             }}
             className="inline-flex shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/[0.04] p-2 text-gray-400 transition hover:border-red-400/60 hover:text-red-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-400 focus-visible:ring-0 sm:relative sm:z-10"
@@ -162,78 +234,233 @@ const PreviewCard = ({
         {achievement.verificationNote ? <span>Verification Note</span> : null}
       </div>
     </motion.article>
-  )
-}
+  );
+};
 
 export default function AdminPage() {
-  const [form, setForm] = useState<AchievementForm>(initialFormState)
-  const [certifications, setCertifications] = useState<Achievement[]>(certificateData)
-  const [badges, setBadges] = useState<Achievement[]>(badgeData)
-  const [categories, setCategories] = useState<string[]>(defaultCategories)
-  const [newCategory, setNewCategory] = useState('')
-  const [activeTab, setActiveTab] = useState<AchievementKind>('certificate')
+  const [form, setForm] = useState<AchievementForm>(initialFormState);
+  const [certifications, setCertifications] =
+    useState<Achievement[]>(certificateData);
+  const [badges, setBadges] = useState<Achievement[]>(badgeData);
+  const [categories, setCategories] = useState<string[]>(defaultCategories);
+  const [newCategory, setNewCategory] = useState("");
+  const [activeTab, setActiveTab] = useState<AchievementKind>("certificate");
+  const [credlyItems, setCredlyItems] = useState<CredlyEmbed[]>(() => {
+    const stored = readCredlyStorage();
+    return mergeCredlyLists(credlyBadges, stored);
+  });
+  const [credlyForm, setCredlyForm] =
+    useState<CredlyFormState>(initialCredlyForm);
+  const [credlyError, setCredlyError] = useState<string | null>(null);
+  const hasPersistedCredlyRef = useRef(false);
 
   const makeKey = (achievement: Achievement) =>
-    [achievement.kind, achievement.title, achievement.issuer, achievement.date].join('::')
+    [
+      achievement.kind,
+      achievement.title,
+      achievement.issuer,
+      achievement.date,
+    ].join("::");
+
+  useEffect(() => {
+    const handleScriptLoad = () => {
+      window.Credly?.Tracker?.init?.();
+    };
+
+    const existingScript = document.querySelector<HTMLScriptElement>(
+      `script[src="${credlyScriptSrc}"]`,
+    );
+
+    if (existingScript) {
+      if (window.Credly) {
+        handleScriptLoad();
+      } else {
+        existingScript.addEventListener("load", handleScriptLoad);
+      }
+
+      return () => {
+        existingScript.removeEventListener("load", handleScriptLoad);
+      };
+    }
+
+    const script = document.createElement("script");
+    script.src = credlyScriptSrc;
+    script.async = true;
+    script.addEventListener("load", handleScriptLoad);
+    document.body.appendChild(script);
+
+    return () => {
+      script.removeEventListener("load", handleScriptLoad);
+    };
+  }, []);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      window.Credly?.Tracker?.init?.();
+    }, 60);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [credlyItems]);
+
+  useEffect(() => {
+    if (!hasPersistedCredlyRef.current) {
+      hasPersistedCredlyRef.current = true;
+      return;
+    }
+
+    writeCredlyStorage(credlyItems);
+    window.dispatchEvent(
+      new CustomEvent(credlyUpdateEvent, { detail: credlyItems }),
+    );
+  }, [credlyItems]);
 
   useEffect(() => {
     if (!categories.includes(form.category)) {
-      setForm((prev) => ({ ...prev, category: categories[0] ?? 'General' }))
+      setForm((prev) => ({ ...prev, category: categories[0] ?? "General" }));
     }
-  }, [categories, form.category])
+  }, [categories, form.category]);
 
-  const previewItems = activeTab === 'certificate' ? certifications : badges
+  const previewItems = activeTab === "certificate" ? certifications : badges;
 
   const handleDelete = (achievement: Achievement) => {
-    if (achievement.kind === 'certificate') {
-      setCertifications((prev) => prev.filter((item) => makeKey(item) !== makeKey(achievement)))
-      return
+    if (achievement.kind === "certificate") {
+      setCertifications((prev) =>
+        prev.filter((item) => makeKey(item) !== makeKey(achievement)),
+      );
+      return;
     }
 
-    setBadges((prev) => prev.filter((item) => makeKey(item) !== makeKey(achievement)))
-  }
+    setBadges((prev) =>
+      prev.filter((item) => makeKey(item) !== makeKey(achievement)),
+    );
+  };
 
   const addCategory = () => {
-    const value = newCategory.trim()
-    if (!value) return
+    const value = newCategory.trim();
+    if (!value) return;
     if (!categories.some((cat) => cat.toLowerCase() === value.toLowerCase())) {
-      setCategories((prev) => [...prev, value])
+      setCategories((prev) => [...prev, value]);
     }
-    setForm((prev) => ({ ...prev, category: value }))
-    setNewCategory('')
-  }
+    setForm((prev) => ({ ...prev, category: value }));
+    setNewCategory("");
+  };
 
-  const resetForm = () => {
+  const resetForm = useCallback(() => {
     setForm((prev) => ({
       ...initialFormState,
-      category: categories[0] ?? 'General',
+      category: categories[0] ?? "General",
       kind: prev.kind,
-    }))
-  }
+    }));
+  }, [categories, setForm]);
+
+  const resetCredlyForm = useCallback(() => {
+    setCredlyForm((prev) => ({
+      ...initialCredlyForm,
+      category: prev.category,
+    }));
+    setCredlyError(null);
+  }, [setCredlyError, setCredlyForm]);
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
+    event.preventDefault();
     const payload: Achievement = {
       ...form,
       takeaway: form.takeaway?.trim() ? form.takeaway : undefined,
       imageUrl: form.imageUrl?.trim() ? form.imageUrl : undefined,
       previewUrl: form.previewUrl?.trim() ? form.previewUrl : undefined,
-      credentialUrl: form.credentialUrl?.trim() ? form.credentialUrl : undefined,
+      credentialUrl: form.credentialUrl?.trim()
+        ? form.credentialUrl
+        : undefined,
       pdfUrl: form.pdfUrl?.trim() ? form.pdfUrl : undefined,
-      verificationNote: form.verificationNote?.trim() ? form.verificationNote : undefined,
-    }
+      verificationNote: form.verificationNote?.trim()
+        ? form.verificationNote
+        : undefined,
+    };
 
-    if (form.kind === 'certificate') {
-      setCertifications((prev) => [payload, ...prev])
+    if (form.kind === "certificate") {
+      setCertifications((prev) => [payload, ...prev]);
     } else {
-      setBadges((prev) => [payload, ...prev])
+      setBadges((prev) => [payload, ...prev]);
     }
 
-    resetForm()
-    setActiveTab(form.kind)
-  }
+    resetForm();
+    setActiveTab(form.kind);
+  };
 
-  const isUpcoming = form.status === 'upcoming'
+  const isUpcoming = form.status === "upcoming";
+
+  const handleCredlyInputChange = useCallback(
+    (value: string) => {
+      const badgeId = extractCredlyBadgeId(value);
+
+      setCredlyForm((prev) => ({
+        ...prev,
+        rawInput: value,
+        badgeId,
+      }));
+
+      if (!value.trim()) {
+        setCredlyError(null);
+        return;
+      }
+
+      setCredlyError(
+        badgeId
+          ? null
+          : "Unable to find a Credly badge UUID in the provided snippet or URL.",
+      );
+    },
+    [setCredlyError, setCredlyForm],
+  );
+
+  const handleCredlySubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const parsedBadgeId =
+        credlyForm.badgeId || extractCredlyBadgeId(credlyForm.rawInput);
+
+      if (!parsedBadgeId) {
+        setCredlyError(
+          "Provide a Credly embed snippet or public badge URL so we can detect the badge UUID.",
+        );
+        return;
+      }
+
+      const payload: CredlyEmbed = {
+        badgeId: parsedBadgeId,
+        category: credlyForm.category,
+        title: credlyForm.title.trim() || undefined,
+        issuer: credlyForm.issuer.trim() || undefined,
+      };
+
+      setCredlyItems((prev) => {
+        const filtered = prev.filter((item) => item.badgeId !== parsedBadgeId);
+        return [payload, ...filtered];
+      });
+
+      resetCredlyForm();
+    },
+    [credlyForm, resetCredlyForm, setCredlyError, setCredlyItems],
+  );
+
+  const handleCredlyDelete = useCallback(
+    (badge: CredlyEmbed) => {
+      if (
+        !window.confirm(
+          `Remove badge ${badge.badgeId}? This only updates the preview list.`,
+        )
+      ) {
+        return;
+      }
+
+      setCredlyItems((prev) =>
+        prev.filter((item) => item.badgeId !== badge.badgeId),
+      );
+    },
+    [setCredlyItems],
+  );
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-dark to-dark-lighter py-16">
@@ -250,10 +477,15 @@ export default function AdminPage() {
               Achievement Management Hub
             </h1>
             <p className="text-sm text-gray-400 sm:text-base">
-              This tucked-away dashboard lets you organise certifications and badges without exposing the controls publicly. Add new achievements, reserve upcoming slots, and keep categories tidy for the main portfolio page.
+              This tucked-away dashboard lets you organise certifications and
+              badges without exposing the controls publicly. Add new
+              achievements, reserve upcoming slots, and keep categories tidy for
+              the main portfolio page.
             </p>
             <div className="text-xs text-gray-500">
-              <span className="font-medium text-primary">Heads up:</span> This page is intentionally hidden from navigation. Bookmark it for quick access when you need to update your achievements.
+              <span className="font-medium text-primary">Heads up:</span> This
+              page is intentionally hidden from navigation. Bookmark it for
+              quick access when you need to update your achievements.
             </div>
           </div>
         </header>
@@ -265,7 +497,9 @@ export default function AdminPage() {
             className="flex flex-col gap-6 rounded-2xl border border-white/10 bg-white/[0.04] p-6 shadow-lg"
           >
             <div className="flex flex-wrap items-center justify-between gap-3">
-              <h2 className="text-xl font-semibold text-white">Add a new achievement</h2>
+              <h2 className="text-xl font-semibold text-white">
+                Add a new achievement
+              </h2>
               <div className="flex items-center gap-2 text-xs text-gray-400">
                 <FiPlusCircle className="h-4 w-4 text-primary" />
                 <span>Fields marked optional can be left blank.</span>
@@ -293,7 +527,9 @@ export default function AdminPage() {
                   required
                   placeholder="e.g. CCNP Enterprise"
                   value={form.title}
-                  onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
+                  onChange={(event) =>
+                    setForm((prev) => ({ ...prev, title: event.target.value }))
+                  }
                 />
               </div>
               <div className="grid gap-2">
@@ -302,16 +538,23 @@ export default function AdminPage() {
                   required
                   placeholder="Organisation or platform"
                   value={form.issuer}
-                  onChange={(event) => setForm((prev) => ({ ...prev, issuer: event.target.value }))}
+                  onChange={(event) =>
+                    setForm((prev) => ({ ...prev, issuer: event.target.value }))
+                  }
                 />
               </div>
               <div className="grid gap-2">
-                <FieldLabel label="Date" helper="Use a friendly format (e.g. June 2025 or Q3 2025)." />
+                <FieldLabel
+                  label="Date"
+                  helper="Use a friendly format (e.g. June 2025 or Q3 2025)."
+                />
                 <Input
                   required
                   placeholder="June 2025"
                   value={form.date}
-                  onChange={(event) => setForm((prev) => ({ ...prev, date: event.target.value }))}
+                  onChange={(event) =>
+                    setForm((prev) => ({ ...prev, date: event.target.value }))
+                  }
                 />
               </div>
 
@@ -323,7 +566,12 @@ export default function AdminPage() {
                 <div className="flex flex-col gap-3">
                   <select
                     value={form.category}
-                    onChange={(event) => setForm((prev) => ({ ...prev, category: event.target.value }))}
+                    onChange={(event) =>
+                      setForm((prev) => ({
+                        ...prev,
+                        category: event.target.value,
+                      }))
+                    }
                     className="w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
                   >
                     {categories.map((category) => (
@@ -351,15 +599,18 @@ export default function AdminPage() {
               </div>
 
               <div className="grid gap-3">
-                <FieldLabel label="Status" helper="Switch to upcoming to reserve a placeholder slot." />
+                <FieldLabel
+                  label="Status"
+                  helper="Switch to upcoming to reserve a placeholder slot."
+                />
                 <div className="grid gap-3 sm:grid-cols-2">
                   {statusOptions.map((option) => (
                     <label
                       key={option.value}
                       className={`flex cursor-pointer flex-col gap-2 rounded-xl border px-4 py-3 text-sm transition ${
                         form.status === option.value
-                          ? 'border-primary bg-primary/10 text-primary'
-                          : 'border-white/10 bg-white/[0.02] text-gray-300 hover:border-primary/40'
+                          ? "border-primary bg-primary/10 text-primary"
+                          : "border-white/10 bg-white/[0.02] text-gray-300 hover:border-primary/40"
                       }`}
                     >
                       <input
@@ -375,8 +626,12 @@ export default function AdminPage() {
                         }
                         className="hidden"
                       />
-                      <span className="font-semibold uppercase tracking-wide">{option.label}</span>
-                      <span className="text-xs text-gray-400">{option.helper}</span>
+                      <span className="font-semibold uppercase tracking-wide">
+                        {option.label}
+                      </span>
+                      <span className="text-xs text-gray-400">
+                        {option.helper}
+                      </span>
                     </label>
                   ))}
                 </div>
@@ -391,53 +646,89 @@ export default function AdminPage() {
                   rows={3}
                   placeholder="Summarise what this milestone means for your growth."
                   value={form.takeaway}
-                  onChange={(event) => setForm((prev) => ({ ...prev, takeaway: event.target.value }))}
+                  onChange={(event) =>
+                    setForm((prev) => ({
+                      ...prev,
+                      takeaway: event.target.value,
+                    }))
+                  }
                 />
               </div>
 
               <div className="grid gap-4 rounded-xl border border-white/10 bg-dark/40 p-4">
-                <span className="text-sm font-medium text-white">Verification resources</span>
+                <span className="text-sm font-medium text-white">
+                  Verification resources
+                </span>
                 <div className="grid gap-4 sm:grid-cols-2">
                   <div className="grid gap-2">
                     <FieldLabel
                       label="Preview image URL"
                       helper={
                         isUpcoming
-                          ? 'Optional for upcoming achievements.'
-                          : 'Displays in the main achievements grid.'
+                          ? "Optional for upcoming achievements."
+                          : "Displays in the main achievements grid."
                       }
                     />
                     <Input
                       placeholder="/images/preview/example.png"
                       value={form.previewUrl}
-                      onChange={(event) => setForm((prev) => ({ ...prev, previewUrl: event.target.value }))}
+                      onChange={(event) =>
+                        setForm((prev) => ({
+                          ...prev,
+                          previewUrl: event.target.value,
+                        }))
+                      }
                       disabled={isUpcoming}
                     />
                   </div>
                   <div className="grid gap-2">
-                    <FieldLabel label="Badge image URL" helper="Shown on the card when available." />
+                    <FieldLabel
+                      label="Badge image URL"
+                      helper="Shown on the card when available."
+                    />
                     <Input
                       placeholder="/images/example.png"
                       value={form.imageUrl}
-                      onChange={(event) => setForm((prev) => ({ ...prev, imageUrl: event.target.value }))}
+                      onChange={(event) =>
+                        setForm((prev) => ({
+                          ...prev,
+                          imageUrl: event.target.value,
+                        }))
+                      }
                       disabled={isUpcoming}
                     />
                   </div>
                   <div className="grid gap-2">
-                    <FieldLabel label="Credential URL" helper="Link to Credly or issuing platform." />
+                    <FieldLabel
+                      label="Credential URL"
+                      helper="Link to Credly or issuing platform."
+                    />
                     <Input
                       placeholder="https://www.credly.com/..."
                       value={form.credentialUrl}
-                      onChange={(event) => setForm((prev) => ({ ...prev, credentialUrl: event.target.value }))}
+                      onChange={(event) =>
+                        setForm((prev) => ({
+                          ...prev,
+                          credentialUrl: event.target.value,
+                        }))
+                      }
                       disabled={isUpcoming}
                     />
                   </div>
                   <div className="grid gap-2">
-                    <FieldLabel label="PDF URL" helper="Direct link to certificate PDF." />
+                    <FieldLabel
+                      label="PDF URL"
+                      helper="Direct link to certificate PDF."
+                    />
                     <Input
                       placeholder="/certifications/example.pdf"
                       value={form.pdfUrl}
-                      onChange={(event) => setForm((prev) => ({ ...prev, pdfUrl: event.target.value }))}
+                      onChange={(event) =>
+                        setForm((prev) => ({
+                          ...prev,
+                          pdfUrl: event.target.value,
+                        }))
+                      }
                       disabled={isUpcoming}
                     />
                   </div>
@@ -450,7 +741,12 @@ export default function AdminPage() {
                   <Input
                     placeholder="Verification available on request."
                     value={form.verificationNote}
-                    onChange={(event) => setForm((prev) => ({ ...prev, verificationNote: event.target.value }))}
+                    onChange={(event) =>
+                      setForm((prev) => ({
+                        ...prev,
+                        verificationNote: event.target.value,
+                      }))
+                    }
                     disabled={isUpcoming}
                   />
                 </div>
@@ -479,9 +775,12 @@ export default function AdminPage() {
           <section className="flex flex-col gap-6 rounded-2xl border border-white/10 bg-white/[0.02] p-6 shadow-lg">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
-                <h2 className="text-xl font-semibold text-white">Live preview</h2>
+                <h2 className="text-xl font-semibold text-white">
+                  Live preview
+                </h2>
                 <p className="text-xs text-gray-400">
-                  Review how the public grid will look before publishing any changes.
+                  Review how the public grid will look before publishing any
+                  changes.
                 </p>
               </div>
               <Link
@@ -494,7 +793,11 @@ export default function AdminPage() {
 
             <div className="flex flex-wrap gap-3">
               {(Object.keys(tabCopy) as AchievementKind[]).map((key) => (
-                <TabButton key={key} isActive={activeTab === key} onClick={() => setActiveTab(key)}>
+                <TabButton
+                  key={key}
+                  isActive={activeTab === key}
+                  onClick={() => setActiveTab(key)}
+                >
                   <FiAward className="h-4 w-4" />
                   {tabCopy[key].title}
                 </TabButton>
@@ -516,12 +819,253 @@ export default function AdminPage() {
             ) : (
               <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-white/10 bg-dark/40 p-10 text-center text-sm text-gray-400">
                 <FiAward className="h-6 w-6 text-primary" />
-                <p>No achievements yet. Start by adding a new record on the left.</p>
+                <p>
+                  No achievements yet. Start by adding a new record on the left.
+                </p>
               </div>
             )}
           </section>
         </section>
+
+        <section className="rounded-2xl border border-white/10 bg-white/[0.02] p-6 shadow-lg">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="max-w-2xl space-y-2">
+              <h2 className="text-xl font-semibold text-white">
+                Credly badge embeds
+              </h2>
+              <p className="text-xs text-gray-400 sm:text-sm">
+                Control the badges that appear on the public Certifications
+                &amp; Badges section. Paste the embed code or a public badge
+                URL, optionally add metadata, and review the live embeds without
+                leaving this page.
+              </p>
+            </div>
+            <span className="text-xs font-semibold uppercase tracking-[0.35em] text-primary/70">
+              Credly
+            </span>
+          </div>
+
+          <div className="mt-8 grid gap-8 lg:grid-cols-[minmax(0,420px)_1fr]">
+            <form
+              onSubmit={handleCredlySubmit}
+              className="flex flex-col gap-6 rounded-2xl border border-white/10 bg-dark/40 p-6"
+            >
+              <div className="grid gap-4">
+                <div className="grid gap-2">
+                  <FieldLabel
+                    label="Credly embed snippet or badge URL"
+                    helper="Paste the iframe embed snippet from Credly or a public badge URL. We'll auto-detect the badge UUID."
+                  />
+                  <TextArea
+                    rows={4}
+                    placeholder='<div class="credly-badge" data-share-badge-id="..." /> or https://www.credly.com/badges/...'
+                    value={credlyForm.rawInput}
+                    onChange={(event) =>
+                      handleCredlyInputChange(event.target.value)
+                    }
+                    className="min-h-[150px]"
+                  />
+                  {credlyError ? (
+                    <p className="text-xs text-red-400">{credlyError}</p>
+                  ) : credlyForm.badgeId ? (
+                    <p className="text-xs text-emerald-400">
+                      Badge detected successfully.
+                    </p>
+                  ) : null}
+                </div>
+
+                <div className="grid gap-2">
+                  <FieldLabel
+                    label="Detected badge UUID"
+                    helper="This value powers the embed. Double-check it matches the intended badge before saving."
+                  />
+                  <Input
+                    value={credlyForm.badgeId}
+                    readOnly
+                    placeholder="Badge UUID will appear once detected"
+                  />
+                </div>
+
+                <div className="grid gap-2">
+                  <FieldLabel
+                    label="Category"
+                    helper="Choose where the badge will appear on the public page."
+                  />
+                  <select
+                    value={credlyForm.category}
+                    onChange={(event) =>
+                      setCredlyForm((prev) => ({
+                        ...prev,
+                        category: event.target.value as CredlyCategory,
+                      }))
+                    }
+                    className="w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                  >
+                    {credlyCategoryOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="grid gap-2">
+                  <FieldLabel
+                    label="Title (optional)"
+                    helper="Override the badge title shown in the portfolio. Leave blank to use Credly's default."
+                  />
+                  <Input
+                    placeholder="e.g. AWS Certified Cloud Practitioner"
+                    value={credlyForm.title}
+                    onChange={(event) =>
+                      setCredlyForm((prev) => ({
+                        ...prev,
+                        title: event.target.value,
+                      }))
+                    }
+                  />
+                </div>
+
+                <div className="grid gap-2">
+                  <FieldLabel
+                    label="Issuer (optional)"
+                    helper="Add context about the awarding organisation."
+                  />
+                  <Input
+                    placeholder="e.g. Amazon Web Services"
+                    value={credlyForm.issuer}
+                    onChange={(event) =>
+                      setCredlyForm((prev) => ({
+                        ...prev,
+                        issuer: event.target.value,
+                      }))
+                    }
+                  />
+                </div>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3">
+                <button
+                  type="submit"
+                  className="flex items-center gap-2 rounded-md bg-primary px-5 py-2 text-sm font-semibold uppercase tracking-wide text-white shadow-lg transition hover:bg-secondary"
+                >
+                  <FiPlusCircle className="h-4 w-4" />
+                  Save badge
+                </button>
+                <button
+                  type="button"
+                  onClick={resetCredlyForm}
+                  className="flex items-center gap-2 rounded-md border border-white/10 px-4 py-2 text-xs uppercase tracking-wide text-gray-300 transition hover:border-primary/60 hover:text-primary"
+                >
+                  <FiRefreshCcw className="h-4 w-4" />
+                  Reset
+                </button>
+              </div>
+            </form>
+
+            <div className="flex flex-col gap-6">
+              <div>
+                <h3 className="text-lg font-semibold text-white">
+                  Live embed preview
+                </h3>
+                <p className="text-xs text-gray-400 sm:text-sm">
+                  Badges render exactly as they will on the public site.
+                  Deleting an item only affects this local preview list.
+                </p>
+              </div>
+
+              <div className="grid gap-8">
+                {credlyCategoryOptions.map((option) => {
+                  const items = credlyItems.filter(
+                    (item) => item.category === option.value,
+                  );
+
+                  return (
+                    <div key={option.value} className="space-y-4">
+                      <div>
+                        <h4 className="text-sm font-semibold uppercase tracking-wide text-gray-300">
+                          {option.label}
+                        </h4>
+                        <p className="text-xs text-gray-500">
+                          {credlyCategoryDescriptions[option.value]}
+                        </p>
+                      </div>
+
+                      {items.length > 0 ? (
+                        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                          {items.map((item) => {
+                            const title = item.title ?? "Credly Badge";
+
+                            return (
+                              <div
+                                key={item.badgeId}
+                                className="group relative flex h-full flex-col gap-4 rounded-2xl border border-white/10 bg-gradient-to-b from-white/5 via-dark/30 to-dark/40 p-4 shadow-lg shadow-black/10 backdrop-blur-sm"
+                              >
+                                <div className="flex items-start justify-between gap-3">
+                                  <div className="space-y-2">
+                                    {item.issuer ? (
+                                      <p className="text-[11px] uppercase tracking-[0.35em] text-primary/70">
+                                        {item.issuer}
+                                      </p>
+                                    ) : null}
+                                    <h5 className="text-base font-semibold text-white">
+                                      {title}
+                                    </h5>
+                                    <p className="text-[11px] font-mono text-gray-500">
+                                      {item.badgeId}
+                                    </p>
+                                  </div>
+                                  <button
+                                    type="button"
+                                    onClick={() => handleCredlyDelete(item)}
+                                    className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/10 text-gray-400 transition hover:border-red-400/60 hover:text-red-400"
+                                    aria-label={`Delete ${title}`}
+                                  >
+                                    <FiTrash2 className="h-4 w-4" />
+                                  </button>
+                                </div>
+                                <div className="relative flex grow items-center justify-center rounded-xl border border-white/10 bg-black/20 p-3">
+                                  <div className="credly-badge-frame w-full max-w-[280px]">
+                                    <div
+                                      className="credly-badge block h-[280px] w-full"
+                                      data-iframe-width="280"
+                                      data-iframe-height="280"
+                                      data-hide-footer="true"
+                                      data-hide-share="true"
+                                      data-share-badge-id={item.badgeId}
+                                      data-share-badge-host="https://www.credly.com"
+                                    />
+                                    <span
+                                      className="credly-badge-overlay"
+                                      aria-hidden="true"
+                                    />
+                                  </div>
+                                </div>
+                                <a
+                                  href={`https://www.credly.com/badges/${item.badgeId}`}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-xs font-medium uppercase tracking-wide text-primary transition hover:text-secondary"
+                                >
+                                  View on Credly
+                                </a>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      ) : (
+                        <div className="rounded-xl border border-dashed border-white/10 bg-dark/40 p-8 text-center text-xs text-gray-500">
+                          No badges saved for this category yet.
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
       </div>
     </div>
-  )
+  );
 }

--- a/src/components/Certifications.tsx
+++ b/src/components/Certifications.tsx
@@ -1,148 +1,128 @@
-'use client'
+"use client";
 
-import { useEffect } from 'react'
-import { motion } from 'framer-motion'
-import { fadeIn } from '../lib/animations'
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { fadeIn } from "../lib/animations";
+import {
+  credlyBadges,
+  credlyStorageKey,
+  credlyUpdateEvent,
+  mergeCredlyLists,
+  readCredlyStorage,
+} from "../lib/credly";
+import type { CredlyCategory, CredlyEmbed } from "../lib/credly";
 
-type CredlyCategory = 'certification' | 'badge'
-
-type CredlyBadge = {
-  title: string
-  issuer: string
-  badgeId: string
-  category: CredlyCategory
-}
-
-declare global {
-  interface Window {
-    Credly?: {
-      Tracker?: {
-        init?: () => void
-      }
-    }
-  }
-}
-
-const credlyBadges: CredlyBadge[] = [
-  {
-    title: 'Cisco Certificate in Ethical Hacking',
-    issuer: 'Cisco',
-    badgeId: '0d215f80-e5e7-456a-b72b-c09fc9be56a9',
-    category: 'certification',
-  },
-  {
-    title: 'Offensive Security Capture the Flag - Operation SMB Exploit',
-    issuer: 'Offensive Security',
-    badgeId: '786bdf71-3683-4ece-87c7-de90f4cce300',
-    category: 'certification',
-  },
-  {
-    title: 'CompTIA IT Fundamentals+ (ITF+)',
-    issuer: 'CompTIA',
-    badgeId: '36adc4b9-65c8-4355-9998-b9ef00f8219a',
-    category: 'certification',
-  },
-  {
-    title: 'Fortinet Certified Associate Cybersecurity',
-    issuer: 'Fortinet',
-    badgeId: '4d6e82bd-7017-4f13-8680-38922ce466fe',
-    category: 'certification',
-  },
-  {
-    title: 'Fortinet FortiGate 7.6 Operator',
-    issuer: 'Fortinet',
-    badgeId: '7803dc94-e30f-4e4a-b78c-b76e322b3e24',
-    category: 'certification',
-  },
-  {
-    title: 'Ethical Hacker',
-    issuer: 'Certiport',
-    badgeId: 'a1cb42eb-783c-462a-ab49-f284c7f0b356',
-    category: 'certification',
-  },
-  {
-    title: 'CCNA: Enterprise Networking, Security, and Automation',
-    issuer: 'Cisco',
-    badgeId: 'c3abddc5-2676-415a-9869-03068e42a2e6',
-    category: 'certification',
-  },
-  {
-    title: 'English for IT 1',
-    issuer: 'Cisco',
-    badgeId: '6a7b0e9e-6f25-4352-97a8-542f9f5f8b1a',
-    category: 'badge',
-  },
-  {
-    title: 'AWS Academy Graduate – Cloud Security Foundations',
-    issuer: 'AWS Academy',
-    badgeId: '0825997e-fb13-49e6-82ef-f1e151803123',
-    category: 'badge',
-  },
-  {
-    title: 'Introduction to Modern AI',
-    issuer: 'Cisco',
-    badgeId: 'aeacf824-5ad5-489a-9bd4-34bbf8c38efd',
-    category: 'badge',
-  },
-  {
-    title: 'Networking Academy Learn-A-Thon 2025',
-    issuer: 'Cisco',
-    badgeId: '013dd79e-503e-45c7-b5d5-b29dee83d61e',
-    category: 'badge',
-  },
-]
+const MotionSection = motion.section;
+const MotionArticle = motion.article;
 
 const sections = [
   {
-    title: 'Professional Certifications',
+    title: "Professional Certifications",
     description:
-      'Industry-recognised credentials earned through rigorous assessments and hands-on validation.',
-    filter: 'certification' as CredlyCategory,
+      "Industry-recognised credentials earned through rigorous assessments and hands-on validation.",
+    filter: "certification" as CredlyCategory,
   },
   {
-    title: 'Digital Badges & Challenges',
+    title: "Digital Badges & Challenges",
     description:
-      'Micro-credentials and competitive challenges that highlight continued learning and practical expertise.',
-    filter: 'badge' as CredlyCategory,
+      "Micro-credentials and competitive challenges that highlight continued learning and practical expertise.",
+    filter: "badge" as CredlyCategory,
   },
-]
+];
 
 const badgeCardVariants = {
   hidden: { opacity: 0, y: 18 },
   visible: { opacity: 1, y: 0 },
-}
+};
 
 export default function Certifications() {
-  useEffect(() => {
-    const scriptSrc = 'https://cdn.credly.com/assets/utilities/embed.js'
-    const handleScriptLoad = () => {
-      window.Credly?.Tracker?.init?.()
-    }
+  const [badgeItems, setBadgeItems] = useState<CredlyEmbed[]>(credlyBadges);
 
-    const existingScript = document.querySelector<HTMLScriptElement>(`script[src="${scriptSrc}"]`)
+  useEffect(() => {
+    const loadStoredBadges = () => {
+      const stored = readCredlyStorage();
+
+      if (!stored) {
+        setBadgeItems((current) =>
+          current === credlyBadges ? current : credlyBadges,
+        );
+        return;
+      }
+
+      setBadgeItems((current) => {
+        const merged = mergeCredlyLists(credlyBadges, stored);
+        if (merged.length === current.length) {
+          const hasDifference = merged.some(
+            (item, index) => item.badgeId !== current[index]?.badgeId,
+          );
+          if (!hasDifference) return current;
+        }
+        return merged;
+      });
+    };
+
+    loadStoredBadges();
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key && event.key !== credlyStorageKey) return;
+      loadStoredBadges();
+    };
+
+    const handleCustomUpdate = () => {
+      loadStoredBadges();
+    };
+
+    window.addEventListener("storage", handleStorage);
+    window.addEventListener(credlyUpdateEvent, handleCustomUpdate);
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+      window.removeEventListener(credlyUpdateEvent, handleCustomUpdate);
+    };
+  }, []);
+
+  useEffect(() => {
+    const scriptSrc = "https://cdn.credly.com/assets/utilities/embed.js";
+    const handleScriptLoad = () => {
+      window.Credly?.Tracker?.init?.();
+    };
+
+    const existingScript = document.querySelector<HTMLScriptElement>(
+      `script[src="${scriptSrc}"]`,
+    );
 
     if (existingScript) {
       if (window.Credly) {
-        handleScriptLoad()
+        handleScriptLoad();
       } else {
-        existingScript.addEventListener('load', handleScriptLoad)
+        existingScript.addEventListener("load", handleScriptLoad);
       }
 
       return () => {
-        existingScript.removeEventListener('load', handleScriptLoad)
-      }
+        existingScript.removeEventListener("load", handleScriptLoad);
+      };
     }
 
-    const script = document.createElement('script')
-    script.src = scriptSrc
-    script.async = true
-    script.addEventListener('load', handleScriptLoad)
-    document.body.appendChild(script)
+    const script = document.createElement("script");
+    script.src = scriptSrc;
+    script.async = true;
+    script.addEventListener("load", handleScriptLoad);
+    document.body.appendChild(script);
 
     return () => {
-      script.removeEventListener('load', handleScriptLoad)
-    }
-  }, [])
+      script.removeEventListener("load", handleScriptLoad);
+    };
+  }, []);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      window.Credly?.Tracker?.init?.();
+    }, 80);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [badgeItems]);
 
   return (
     <section id="certifications" className="section bg-dark-lighter">
@@ -154,18 +134,24 @@ export default function Certifications() {
           variants={fadeIn}
           className="mb-12 text-center"
         >
-          <h2 className="heading text-2xl sm:text-3xl md:text-4xl lg:text-5xl">Certifications &amp; Badges</h2>
+          <h2 className="heading text-2xl sm:text-3xl md:text-4xl lg:text-5xl">
+            Certifications &amp; Badges
+          </h2>
           <p className="text-gray-300 mx-auto mt-4 max-w-3xl text-sm sm:text-base">
-            Explore verifiable digital credentials issued via Credly. Each badge is embedded directly from the
-            issuing authority, ensuring authenticity while aligning with the site&apos;s polished presentation.
+            Explore verifiable digital credentials issued via Credly. Each badge
+            is embedded directly from the issuing authority, ensuring
+            authenticity while aligning with the site&apos;s polished
+            presentation.
           </p>
         </motion.div>
 
         {sections.map((section) => {
-          const items = credlyBadges.filter((badge) => badge.category === section.filter)
+          const items = badgeItems.filter(
+            (badge) => badge.category === section.filter,
+          );
 
           return (
-            <motion.section
+            <MotionSection
               key={section.title}
               initial="hidden"
               whileInView="visible"
@@ -174,55 +160,72 @@ export default function Certifications() {
               className="mb-16"
             >
               <div className="mx-auto mb-8 max-w-3xl text-center">
-                <h3 className="text-xl sm:text-2xl md:text-3xl font-semibold text-white">{section.title}</h3>
-                <p className="mt-3 text-sm text-gray-400 sm:text-base">{section.description}</p>
+                <h3 className="text-xl sm:text-2xl md:text-3xl font-semibold text-white">
+                  {section.title}
+                </h3>
+                <p className="mt-3 text-sm text-gray-400 sm:text-base">
+                  {section.description}
+                </p>
               </div>
 
               <div className="grid gap-6 sm:gap-8 md:grid-cols-2 xl:grid-cols-3">
-                {items.map((badge) => (
-                  <motion.article
-                    key={badge.badgeId}
-                    variants={badgeCardVariants}
-                    initial="hidden"
-                    whileInView="visible"
-                    viewport={{ once: true, amount: 0.3 }}
-                    className="group relative flex h-full flex-col gap-4 rounded-2xl border border-white/10 bg-gradient-to-b from-white/10 via-dark/30 to-dark/40 p-6 shadow-lg shadow-black/10 backdrop-blur-sm transition hover:border-primary/60 hover:shadow-primary/20"
-                  >
-                    <div>
-                      <p className="text-xs uppercase tracking-[0.3em] text-primary/70">{badge.issuer}</p>
-                      <h4 className="mt-3 text-lg font-semibold text-white sm:text-xl">{badge.title}</h4>
-                    </div>
-                    <div className="relative flex grow items-center justify-center rounded-xl border border-white/10 bg-black/20 p-4">
-                      <div className="credly-badge-frame w-full max-w-[340px]">
-                        <div
-                          className="credly-badge block h-[340px] w-full"
-                          data-iframe-width="340"
-                          data-iframe-height="340"
-                          data-hide-footer="true"
-                          data-hide-share="true"
-                          data-share-badge-id={badge.badgeId}
-                          data-share-badge-host="https://www.credly.com"
-                        />
-                        <span className="credly-badge-overlay" aria-hidden="true" />
-                      </div>
-                    </div>
-                    <a
-                      href={`https://www.credly.com/badges/${badge.badgeId}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-xs font-medium uppercase tracking-wide text-primary transition group-hover:text-secondary"
+                {items.map((badge) => {
+                  const badgeTitle = badge.title ?? "Credly Badge";
+
+                  return (
+                    <MotionArticle
+                      key={badge.badgeId}
+                      variants={badgeCardVariants}
+                      initial="hidden"
+                      whileInView="visible"
+                      viewport={{ once: true, amount: 0.3 }}
+                      className="group relative flex h-full flex-col gap-4 rounded-2xl border border-white/10 bg-gradient-to-b from-white/10 via-dark/30 to-dark/40 p-6 shadow-lg shadow-black/10 backdrop-blur-sm transition hover:border-primary/60 hover:shadow-primary/20"
                     >
-                      View on Credly
-                    </a>
-                  </motion.article>
-                ))}
+                      <div>
+                        {badge.issuer ? (
+                          <p className="text-xs uppercase tracking-[0.3em] text-primary/70">
+                            {badge.issuer}
+                          </p>
+                        ) : null}
+                        <h4 className="mt-3 text-lg font-semibold text-white sm:text-xl">
+                          {badgeTitle}
+                        </h4>
+                      </div>
+                      <div className="relative flex grow items-center justify-center rounded-xl border border-white/10 bg-black/20 p-4">
+                        <div className="credly-badge-frame w-full max-w-[340px]">
+                          <div
+                            className="credly-badge block h-[340px] w-full"
+                            data-iframe-width="340"
+                            data-iframe-height="340"
+                            data-hide-footer="true"
+                            data-hide-share="true"
+                            data-share-badge-id={badge.badgeId}
+                            data-share-badge-host="https://www.credly.com"
+                          />
+                          <span
+                            className="credly-badge-overlay"
+                            aria-hidden="true"
+                          />
+                        </div>
+                      </div>
+                      <a
+                        href={`https://www.credly.com/badges/${badge.badgeId}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs font-medium uppercase tracking-wide text-primary transition group-hover:text-secondary"
+                      >
+                        View on Credly
+                      </a>
+                    </MotionArticle>
+                  );
+                })}
               </div>
-            </motion.section>
-          )
+            </MotionSection>
+          );
         })}
 
         <div className="text-center text-gray-400 text-sm sm:text-base">
-          For a comprehensive credential history, visit my{' '}
+          For a comprehensive credential history, visit my{" "}
           <a
             href="https://www.credly.com/users/kenneth-david-santos"
             target="_blank"
@@ -235,5 +238,5 @@ export default function Certifications() {
         </div>
       </div>
     </section>
-  )
+  );
 }

--- a/src/lib/credly.ts
+++ b/src/lib/credly.ts
@@ -1,0 +1,172 @@
+export type CredlyCategory = "certification" | "badge";
+
+export type CredlyEmbed = {
+  badgeId: string;
+  category: CredlyCategory;
+  title?: string;
+  issuer?: string;
+};
+
+declare global {
+  interface Window {
+    Credly?: {
+      Tracker?: {
+        init?: () => void;
+      };
+    };
+  }
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isCredlyEmbed = (value: unknown): value is CredlyEmbed => {
+  if (!isObject(value)) return false;
+
+  const { badgeId, category, title, issuer } = value;
+
+  const hasValidBadgeId = typeof badgeId === "string" && badgeId.length > 0;
+  const hasValidCategory = category === "certification" || category === "badge";
+  const hasValidTitle = title === undefined || typeof title === "string";
+  const hasValidIssuer = issuer === undefined || typeof issuer === "string";
+
+  return hasValidBadgeId && hasValidCategory && hasValidTitle && hasValidIssuer;
+};
+
+const sanitizeCredlyEmbeds = (items: unknown): CredlyEmbed[] => {
+  if (!Array.isArray(items)) return [];
+
+  const deduped: CredlyEmbed[] = [];
+  const seen = new Set<string>();
+
+  for (const item of items) {
+    if (!isCredlyEmbed(item)) continue;
+
+    if (seen.has(item.badgeId)) continue;
+    seen.add(item.badgeId);
+
+    deduped.push(item);
+  }
+
+  return deduped;
+};
+
+export const mergeCredlyLists = (
+  base: CredlyEmbed[],
+  overrides: CredlyEmbed[] | null,
+): CredlyEmbed[] => {
+  if (!overrides?.length) return base;
+
+  const seen = new Set<string>();
+  const merged: CredlyEmbed[] = [];
+
+  for (const item of overrides) {
+    if (seen.has(item.badgeId)) continue;
+    seen.add(item.badgeId);
+    merged.push(item);
+  }
+
+  for (const item of base) {
+    if (seen.has(item.badgeId)) continue;
+    merged.push(item);
+  }
+
+  return merged;
+};
+
+export const credlyStorageKey = "portfolio:credly-badges";
+export const credlyUpdateEvent = "credly-badges-updated";
+
+export const readCredlyStorage = (): CredlyEmbed[] | null => {
+  if (typeof window === "undefined") return null;
+
+  const raw = window.localStorage.getItem(credlyStorageKey);
+  if (raw === null) return null;
+
+  try {
+    return sanitizeCredlyEmbeds(JSON.parse(raw));
+  } catch (error) {
+    console.error("Failed to read Credly badge storage", error);
+    return null;
+  }
+};
+
+export const writeCredlyStorage = (items: CredlyEmbed[]) => {
+  if (typeof window === "undefined") return;
+
+  try {
+    const sanitized = sanitizeCredlyEmbeds(items);
+    window.localStorage.setItem(credlyStorageKey, JSON.stringify(sanitized));
+  } catch (error) {
+    console.error("Failed to persist Credly badge storage", error);
+  }
+};
+
+export const credlyBadges: CredlyEmbed[] = [
+  {
+    title: "Cisco Certificate in Ethical Hacking",
+    issuer: "Cisco",
+    badgeId: "0d215f80-e5e7-456a-b72b-c09fc9be56a9",
+    category: "certification",
+  },
+  {
+    title: "Offensive Security Capture the Flag - Operation SMB Exploit",
+    issuer: "Offensive Security",
+    badgeId: "786bdf71-3683-4ece-87c7-de90f4cce300",
+    category: "certification",
+  },
+  {
+    title: "CompTIA IT Fundamentals+ (ITF+)",
+    issuer: "CompTIA",
+    badgeId: "36adc4b9-65c8-4355-9998-b9ef00f8219a",
+    category: "certification",
+  },
+  {
+    title: "Fortinet Certified Associate Cybersecurity",
+    issuer: "Fortinet",
+    badgeId: "4d6e82bd-7017-4f13-8680-38922ce466fe",
+    category: "certification",
+  },
+  {
+    title: "Fortinet FortiGate 7.6 Operator",
+    issuer: "Fortinet",
+    badgeId: "7803dc94-e30f-4e4a-b78c-b76e322b3e24",
+    category: "certification",
+  },
+  {
+    title: "Ethical Hacker",
+    issuer: "Certiport",
+    badgeId: "a1cb42eb-783c-462a-ab49-f284c7f0b356",
+    category: "certification",
+  },
+  {
+    title: "CCNA: Enterprise Networking, Security, and Automation",
+    issuer: "Cisco",
+    badgeId: "c3abddc5-2676-415a-9869-03068e42a2e6",
+    category: "certification",
+  },
+  {
+    title: "English for IT 1",
+    issuer: "Cisco",
+    badgeId: "6a7b0e9e-6f25-4352-97a8-542f9f5f8b1a",
+    category: "badge",
+  },
+  {
+    title: "AWS Academy Graduate – Cloud Security Foundations",
+    issuer: "AWS Academy",
+    badgeId: "0825997e-fb13-49e6-82ef-f1e151803123",
+    category: "badge",
+  },
+  {
+    title: "Introduction to Modern AI",
+    issuer: "Cisco",
+    badgeId: "aeacf824-5ad5-489a-9bd4-34bbf8c38efd",
+    category: "badge",
+  },
+  {
+    title: "Networking Academy Learn-A-Thon 2025",
+    issuer: "Cisco",
+    badgeId: "013dd79e-503e-45c7-b5d5-b29dee83d61e",
+    category: "badge",
+  },
+];


### PR DESCRIPTION
## Summary
- wrap the Credly form handlers in memoized callbacks so they are defined once
- reuse the shared reset helper during submissions to avoid duplicate logic and redeclarations

## Testing
- npx tsc --noEmit
- npm run build *(fails: sandbox cannot download the Inter font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68fb3291c9548331829b74d9b8d27755