### PR TITLE
Add database provisioning for user information API

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eslint": "^8.56.0",
     "eslint-config-next": "14.1.0",
     "framer-motion": "^11.0.3",
+    "mysql2": "^3.9.7",
     "next": "14.1.0",
     "postcss": "^8.4.35",
     "react": "^18.2.0",

--- a/src/app/api/user-information/route.ts
+++ b/src/app/api/user-information/route.ts
@@ -1,0 +1,123 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+import pool from '@/lib/db'
+import { ensureUserInformationTable } from '@/lib/schema'
+
+type UserInformationPayload = {
+  fullName: string
+  email: string
+  company?: string
+  role?: string
+  location?: string
+  projectContext?: string
+  goals?: string
+  timeline?: string
+  budget?: string
+  message?: string
+  linkedinUrl?: string
+  githubUrl?: string
+  websiteUrl?: string
+  referralSource?: string
+  availability?: string
+  collaborationIdeas?: string
+}
+
+type FieldKey = keyof UserInformationPayload
+
+const FIELD_TO_COLUMN: Record<FieldKey, string> = {
+  fullName: 'full_name',
+  email: 'email',
+  company: 'company',
+  role: 'role',
+  location: 'location',
+  projectContext: 'project_context',
+  goals: 'goals',
+  timeline: 'timeline',
+  budget: 'budget',
+  message: 'message',
+  linkedinUrl: 'linkedin_url',
+  githubUrl: 'github_url',
+  websiteUrl: 'website_url',
+  referralSource: 'referral_source',
+  availability: 'availability',
+  collaborationIdeas: 'collaboration_ideas',
+}
+
+const normalizeValue = (value: unknown): string | null => {
+  if (value === undefined || value === null) return null
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+
+  try {
+    const serialized = JSON.stringify(value)
+    return serialized.length > 0 ? serialized : null
+  } catch (error) {
+    console.error('Failed to serialise user information field', error)
+    return null
+  }
+}
+
+export async function POST(request: NextRequest) {
+  let payload: Partial<UserInformationPayload>
+
+  try {
+    payload = (await request.json()) as Partial<UserInformationPayload>
+  } catch (error) {
+    console.error('Invalid JSON payload received', error)
+    return NextResponse.json({ error: 'Invalid JSON payload.' }, { status: 400 })
+  }
+
+  const fullName = normalizeValue(payload.fullName)
+  const email = normalizeValue(payload.email)
+
+  if (!fullName || !email) {
+    return NextResponse.json(
+      { error: 'Both fullName and email are required to submit user information.' },
+      { status: 400 },
+    )
+  }
+
+  await ensureUserInformationTable()
+
+  const columns: string[] = []
+  const placeholders: string[] = []
+  const values: Array<string> = []
+
+  (Object.entries(FIELD_TO_COLUMN) as Array<[FieldKey, string]>).forEach(([field, column]) => {
+    const normalised = normalizeValue(payload[field])
+
+    if (normalised !== null) {
+      columns.push(column)
+      placeholders.push('?')
+      values.push(normalised)
+    }
+  })
+
+  if (!columns.includes('full_name')) {
+    columns.unshift('full_name')
+    placeholders.unshift('?')
+    values.unshift(fullName)
+  }
+
+  if (!columns.includes('email')) {
+    const index = columns.indexOf('full_name') + 1
+    columns.splice(index, 0, 'email')
+    placeholders.splice(index, 0, '?')
+    values.splice(index, 0, email)
+  }
+
+  const insertStatement = `INSERT INTO user_information (${columns.join(', ')}) VALUES (${placeholders.join(', ')})`
+
+  try {
+    await pool.execute(insertStatement, values)
+  } catch (error) {
+    console.error('Failed to persist user information', error)
+    return NextResponse.json({ error: 'Failed to save the submitted information.' }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true }, { status: 201 })
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,40 @@
+import mysql from 'mysql2/promise'
+
+type MySqlPool = mysql.Pool
+
+declare global {
+  // eslint-disable-next-line no-var
+  var mysqlPool: MySqlPool | undefined
+}
+
+const getRequiredEnv = (key: 'DB_HOST' | 'DB_USER' | 'DB_PASSWORD' | 'DB_NAME'): string => {
+  const value = process.env[key]
+
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`)
+  }
+
+  return value
+}
+
+const createPool = () =>
+  mysql.createPool({
+    host: getRequiredEnv('DB_HOST'),
+    user: getRequiredEnv('DB_USER'),
+    password: getRequiredEnv('DB_PASSWORD'),
+    database: getRequiredEnv('DB_NAME'),
+    waitForConnections: true,
+    connectionLimit: 10,
+    queueLimit: 0,
+    namedPlaceholders: true,
+    charset: 'utf8mb4',
+  })
+
+const pool = globalThis.mysqlPool ?? createPool()
+
+if (process.env.NODE_ENV !== 'production') {
+  globalThis.mysqlPool = pool
+}
+
+export default pool
+export { pool }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,0 +1,48 @@
+import pool from './db'
+
+let ensureUserInformationTablePromise: Promise<void> | null = null
+
+const createUserInformationTable = async () => {
+  const createTableStatement = `
+    CREATE TABLE IF NOT EXISTS user_information (
+      id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+      full_name VARCHAR(255) NOT NULL,
+      email VARCHAR(255) NOT NULL,
+      company VARCHAR(255) NULL,
+      role VARCHAR(255) NULL,
+      location VARCHAR(255) NULL,
+      project_context TEXT NULL,
+      goals TEXT NULL,
+      timeline VARCHAR(255) NULL,
+      budget VARCHAR(255) NULL,
+      message TEXT NULL,
+      linkedin_url VARCHAR(512) NULL,
+      github_url VARCHAR(512) NULL,
+      website_url VARCHAR(512) NULL,
+      referral_source VARCHAR(255) NULL,
+      availability VARCHAR(255) NULL,
+      collaboration_ideas TEXT NULL,
+      created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+      INDEX idx_user_information_email (email),
+      INDEX idx_user_information_created_at (created_at)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  `
+
+  await pool.query(createTableStatement)
+}
+
+export const ensureUserInformationTable = () => {
+  if (!ensureUserInformationTablePromise) {
+    ensureUserInformationTablePromise = createUserInformationTable().catch((error) => {
+      ensureUserInformationTablePromise = null
+      throw error
+    })
+  }
+
+  return ensureUserInformationTablePromise
+}
+
+void ensureUserInformationTable().catch((error) => {
+  console.error('Failed to ensure user_information table exists', error)
+})


### PR DESCRIPTION
## Summary
- add a reusable mysql2/promise connection pool configured from environment variables
- create a schema helper that auto-creates the user_information table with the required columns
- ensure the user-information API route provisions the table before inserting records

## Testing
- not run (environment lacks npm registry access for mysql2 dependency)


------
https://chatgpt.com/codex/tasks/task_e_6901d347917c83318e89f0747e04df7f